### PR TITLE
renamed `viewController(for:)` in `XRouter`

### DIFF
--- a/Example/Router/Config/Router.swift
+++ b/Example/Router/Config/Router.swift
@@ -59,7 +59,7 @@ class Router: XRouter<Route> {
     
     /// Prepare the route for transition and return the view controller
     ///  to transition to on the view hierachy
-    override func prepareForTransition(to route: Route) throws -> UIViewController {
+    override func viewController(for route: Route) throws -> UIViewController {
         switch route {
         case .tab1Home:
             return container.tab1Coordinator.gotoTabHome()

--- a/Example/Tests/RouterTests.swift
+++ b/Example/Tests/RouterTests.swift
@@ -214,7 +214,7 @@ private class MockRouter: MockRouterBase<TestRoute> {
     }
     
     /// Prepare for transition
-    override func prepareForTransition(to route: TestRoute) throws -> UIViewController {
+    override func viewController(for route: TestRoute) throws -> UIViewController {
         switch route {
         case .homeVC,
              .secondHomeVC:

--- a/Example/Tests/RouterURLMatcherTests.swift
+++ b/Example/Tests/RouterURLMatcherTests.swift
@@ -217,7 +217,7 @@ private enum TestRoute: RouteType {
 
 private class MockRouter: MockRouterBase<TestRoute> {
     
-    override func prepareForTransition(to route: TestRoute) throws -> UIViewController {
+    override func viewController(for route: TestRoute) throws -> UIViewController {
         switch route {
         case .exampleStaticRoute:
             let viewController = UIViewController()

--- a/Example/Tests/RoutingHandlerTests.swift
+++ b/Example/Tests/RoutingHandlerTests.swift
@@ -38,7 +38,7 @@ private class MockRouter: MockRouterBase<Route> { }
 
 private class MockRouteHandler: RouteHandler<Route> {
     
-    override func prepareForTransition(to route: Route) throws -> UIViewController {
+    override func viewController(for route: Route) throws -> UIViewController {
         switch route {
         case .example:
             return UIViewController()

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ enum Route: RouteType {
  */
 class Router: XRouter<Route> {
 
-    /// Prepares route destinations.
-    override func prepareForTransition(to route: Route) throws -> UIViewController {
+    /// Configure the destination route view controller.
+    override func viewController(for route: Route) throws -> UIViewController {
         switch route {
         case .newsfeed: return newsfeedController.rootViewController
         case .login: return LoginFlowCoordinator().start()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # XRouter
 
-Navigate anywhere in your iOS app in one line.
+Navigate anywhere in just one line.
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d0ef88b70fc843adb2944ce0d956269d)](https://app.codacy.com/app/hubrioAU/XRouter?utm_source=github.com&utm_medium=referral&utm_content=hubrioAU/XRouter&utm_campaign=Badge_Grade_Dashboard)
 [![CodeCov Badge](https://codecov.io/gh/hubrioAU/XRouter/branch/master/graph/badge.svg)](https://codecov.io/gh/hubrioau/XRouter)
@@ -9,6 +9,7 @@ Navigate anywhere in your iOS app in one line.
 [![Version](https://img.shields.io/cocoapods/v/XRouter.svg?style=flat)](https://cocoapods.org/pods/XRouter)
 [![License](https://img.shields.io/cocoapods/l/XRouter.svg?style=flat)](https://cocoapods.org/pods/XRouter)
 [![Platform](https://img.shields.io/cocoapods/p/XRouter.svg?style=flat)](https://cocoapods.org/pods/XRouter)
+[![Language](https://img.shields.io/badge/language-Swift-ed5036.svg)](https://swift.org)
 
 <p align="center">
 <img src="https://raw.githubusercontent.com/hubrioau/XRouter/master/XRouter.jpg?17-Mar" alt="XRouter" width="400" style="max-width:400px;width:auto;height:auto;"/>
@@ -23,19 +24,10 @@ Navigate anywhere in your iOS app in one line.
  Routes
  */
 enum Route: RouteType {
-
-    /// Newsfeed page
     case newsfeed
-    
-    /// Login flow
     case login
-    
-    /// Signup flow
-    case signup 
-    
-    /// User profile
-    case profile(userID: String)
-    
+    case signup
+    case profile(userID: Int)
 }
 ```
 
@@ -46,7 +38,7 @@ enum Route: RouteType {
  */
 class Router: XRouter<Route> {
 
-    /// Configure the destination route view controller.
+    /// Configure the view controller for the route.
     override func viewController(for route: Route) throws -> UIViewController {
         switch route {
         case .newsfeed: return newsfeedController.rootViewController

--- a/Router/Classes/Navigator.swift
+++ b/Router/Classes/Navigator.swift
@@ -64,7 +64,7 @@ internal class Navigator<R: RouteType> {
         let destination: UIViewController
         
         do {
-            destination = try routeHandler.prepareForTransition(to: route)
+            destination = try routeHandler.viewController(for: route)
         } catch {
             errorHandler(error)
             return

--- a/Router/Classes/RouteHandler.swift
+++ b/Router/Classes/RouteHandler.swift
@@ -24,14 +24,14 @@ open class RouteHandler<R: RouteType> {
     // MARK: - Methods
     
     ///
-    /// Return the view controller for your Route here.
+    /// Configure the view controller for your route here.
     ///
-    /// It can be either a container (i.e. Navigation Controller) or an
+    /// You can either give it the container (i.e. Navigation Controller) or an
     ///   instance of a single view controller.
     ///
-    /// - Note: Throw an Error here to cancel the transition.
+    /// - Note: Throw any `Error` here to cancel the transition.
     ///
-    open func prepareForTransition(to route: R) throws -> UIViewController {
+    open func viewController(for route: R) throws -> UIViewController {
         throw RouterError.routeHasNotBeenConfigured
     }
     

--- a/XRouter.podspec
+++ b/XRouter.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'XRouter'
-  s.version          = '1.4.0'
-  s.summary          = 'The simple routing library for iOS.'
+  s.version          = '1.4.1'
+  s.summary          = 'Navigate anywhere in just one line.'
 
   s.description      = <<-DESC
 A simple routing library for iOS.


### PR DESCRIPTION
`XRouter`
- renamed `prepareForTransition(to:)` to `viewController(for:)`
- refactored `received(unhandledError:)`
